### PR TITLE
Remove empty line from terraform-from-article.prompt.md

### DIFF
--- a/prompts/terraform-prompt/from-article/terraform-from-article.prompt.md
+++ b/prompts/terraform-prompt/from-article/terraform-from-article.prompt.md
@@ -1,4 +1,3 @@
-
 ---
 mode: 'agent'
 description: Generate and test a Terraform template by converting Azure portal, PowerShell, or Azure CLI procedures from a Microsoft Learn article to Infrastructure as Code, including multiple terraform files (main.tf, outputs.tf, providers.tf, ssh.tf, variables.tf), parameter extraction, template deployment, and resource verification.


### PR DESCRIPTION
Removed an empty line at the beginning of the Terraform prompt file.